### PR TITLE
fix: initiate options flow data with config_entry

### DIFF
--- a/custom_components/door_and_window/config_flow.py
+++ b/custom_components/door_and_window/config_flow.py
@@ -41,7 +41,7 @@ class WindowAndDoorDeviceOptionsFlow(config_entries.OptionsFlow):
             The result of the options flow step.
         """
         if user_input is not None:
-            self.data = user_input
+            self.data = self.config_entry.data | user_input
             if user_input[CONF_TYPE] == TYPE_WINDOW:
                 return await self.async_step_window_dimensions()
             else:


### PR DESCRIPTION
## Description

This PR modifies the code to initiate the options flow with the current config_entry settings to preserve unchangeable config values (like `name`).

