### PR TITLE
fix: removes the calling of (non existing) horizon_profile.dispose

### DIFF
--- a/custom_components/door_and_window/models/door_and_window.py
+++ b/custom_components/door_and_window/models/door_and_window.py
@@ -521,8 +521,6 @@ class DoorAndWindow():
         """
         Destroys the current instance.
         """
-        self._horizon_profile.dispose()
-
         for event in self._events.values():
             event.clear_event_listeners()
 


### PR DESCRIPTION
## Description

This PR removes the non existing `horizon_profile.dispose()` call.
