### PR TITLE
refactor: move rectangles handling to DoorAndWindow class

### DIFF
--- a/custom_components/door_and_window/converters/door_and_window_to_rectangles_converter.py
+++ b/custom_components/door_and_window/converters/door_and_window_to_rectangles_converter.py
@@ -1,8 +1,14 @@
 """ Module for door and window to rectangles converter. """
-from ..models.door_and_window import DoorAndWindow
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from ..models.door_and_window_rectangles import DoorAndWindowRectangles
 from ..models.quadrilateral import Quadrilateral
 from ..transformers.coordinate_transformations import CoordinateTransformations
+
+if TYPE_CHECKING:
+    from ..models.door_and_window import DoorAndWindow
 
 # pylint: disable=too-few-public-methods
 

--- a/custom_components/door_and_window/coordinator.py
+++ b/custom_components/door_and_window/coordinator.py
@@ -1,12 +1,8 @@
 """ The module for coordinator. """
-from typing import Callable, List
-
 from homeassistant.core import State
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.typing import HomeAssistantType
 
-from .converters.door_and_window_to_rectangles_converter import \
-    DoorAndWindowToRectanglesConverter
 from .models.door_and_window import DoorAndWindow
 
 
@@ -35,20 +31,6 @@ class Coordinator():
         """
         self._door_and_window = door_and_window
         self._hass = hass
-        self._rectangles = DoorAndWindowToRectanglesConverter().convert(door_and_window)
-
-        # initialize door and window size and facing tracking
-        self._door_and_window_events_disposes: List[Callable[[], None]] = [
-            self._door_and_window.on_azimuth_changed(self._on_needs_rectangles_update),
-            self._door_and_window.on_frame_face_thickness_changed(self._on_needs_rectangles_update),
-            self._door_and_window.on_frame_thickness_changed(self._on_needs_rectangles_update),
-            self._door_and_window.on_height_changed(self._on_needs_rectangles_update),
-            self._door_and_window.on_inside_depth_changed(self._on_needs_rectangles_update),
-            self._door_and_window.on_outside_depth_changed(self._on_needs_rectangles_update),
-            self._door_and_window.on_parapet_wall_height_changed(self._on_needs_rectangles_update),
-            self._door_and_window.on_tilt_changed(self._on_needs_rectangles_update),
-            self._door_and_window.on_width_changed(self._on_needs_rectangles_update),
-        ]
 
         # initialize sun tracking
         self._track_sun_entity_dispose = async_track_state_change(
@@ -73,19 +55,9 @@ class Coordinator():
             float(new_state.attributes['elevation'])
         )
 
-    # pylint: disable=unused-argument
-    def _on_needs_rectangles_update(self, new_value: float):
-        """
-        Updates the rectangles of door and window whenever
-        the door and window size or facing parameters has changed.
-        """
-        self._rectangles = DoorAndWindowToRectanglesConverter().convert(self._door_and_window)
-
     def dispose(self):
         """
         Removes all change tracking.
         """
         self._door_and_window.dispose()
         self._track_sun_entity_dispose()
-        for dispose_door_and_window_event in self._door_and_window_events_disposes:
-            dispose_door_and_window_event()

--- a/custom_components/door_and_window/tests/models/test_door_and_window.py
+++ b/custom_components/door_and_window/tests/models/test_door_and_window.py
@@ -2,9 +2,12 @@
 """Test module for `DoorAndWindow` class."""
 import math
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
+from ...converters.door_and_window_to_rectangles_converter import \
+    DoorAndWindowToRectanglesConverter
 from ...models.door_and_window import DoorAndWindow
 
 
@@ -116,3 +119,55 @@ def test_angle_of_incidence():
 
     door_and_window.update(0, -30)
     assert math.isclose(door_and_window.angle_of_incidence, 30)
+
+
+@pytest.mark.parametrize('prop', [
+    'width',
+    'height',
+    'frame_thickness',
+    'frame_face_thickness',
+    'outside_depth',
+    'inside_depth',
+    'azimuth',
+    'tilt'
+])
+def test_if_rectangles_updated(prop: str):
+    with patch.object(
+        DoorAndWindowToRectanglesConverter,
+        'convert',
+        return_value=None
+    ) as convert_mock:
+        door_and_window = DoorAndWindow(
+            'window',
+            'my window',
+            'manufacturer',
+            'model',
+            900,
+            1200,
+            90,
+            89,
+            100,
+            200,
+            900,
+            0,
+            90,
+            [0, 0]
+        )
+
+        # rectangle converting should not be called before updating
+        convert_mock.assert_not_called()
+
+        door_and_window.update(1, 0)
+
+        # rectangle converting should be called after updating (and no property changed)
+        convert_mock.assert_called_once()
+
+        setattr(door_and_window, prop, 999)
+
+        # should not call rectangle updates
+        convert_mock.assert_called_once()
+
+        door_and_window.update(2, 0)
+
+        # rectangle converting should be called after updating (and no property changed)
+        assert convert_mock.call_count == 2

--- a/custom_components/door_and_window/tests/test_coordinator.py
+++ b/custom_components/door_and_window/tests/test_coordinator.py
@@ -4,9 +4,8 @@ from unittest.mock import ANY, MagicMock, patch
 from ..coordinator import Coordinator
 
 
-@patch('door_and_window.coordinator.DoorAndWindowToRectanglesConverter.convert', return_value=None)
 @patch('door_and_window.coordinator.async_track_state_change', return_value=lambda: None)
-def test_coordinator_init(async_track_state_change_mock, convert_mock):
+def test_coordinator_init(async_track_state_change_mock):
     """
     Tests if the coordinator starts to listening
     to sun position change.
@@ -19,16 +18,12 @@ def test_coordinator_init(async_track_state_change_mock, convert_mock):
     # should track sun's position
     async_track_state_change_mock.assert_called_once_with(hass, "sun.sun", ANY)
 
-    # should generate initial rectangles
-    convert_mock.assert_called_once_with(door_and_window_mock)
-
     coordinator.dispose()
 
 
-@patch('door_and_window.coordinator.DoorAndWindowToRectanglesConverter.convert', return_value=None)
 @patch('door_and_window.coordinator.async_track_state_change', return_value=lambda: None)
 # pylint: disable=unused-argument
-def test_coordinator_dispose(async_track_state_change_mock, convert_mock):
+def test_coordinator_dispose(async_track_state_change_mock):
     """
     Tests if the dispose method of door and window called
     in case of coordinator disposing.


### PR DESCRIPTION
## Description

This PR refactors the code and moves the rectangle creation and tracking of door and window size and facing parameters into the `DoorAndWindow` class.
