### PR TITLE
fix: remove 'iot_class' from hacs.json

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,6 @@
 {
     "name": "Door and window integration",
     "render_readme": true,
-    "iot_class": "Calculated",
     "zip_release": true,
     "filename": "homeassistant-door-and-window.zip"
 }


### PR DESCRIPTION
## Description

This PR removes deprecated `iot_class` attribute from `hacs.json`.


